### PR TITLE
Fix #1: Return 401 on invalid login credentials

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -28,13 +28,12 @@ router.post("/login", (req, res) => {
 
   const user = users.find((u) => u.username === username);
 
-  // BUG: Returns 200 even on invalid password — just returns different message
   if (!user) {
-    return res.status(200).json({ message: "User not found" });
+    return res.status(401).json({ message: "Invalid username or password" });
   }
 
   if (user.password !== password) {
-    return res.status(200).json({ message: "Invalid password" });
+    return res.status(401).json({ message: "Invalid username or password" });
   }
 
   // BUG: Token is just the user ID — no actual JWT or signing

--- a/src/tasks.test.js
+++ b/src/tasks.test.js
@@ -79,14 +79,21 @@ describe("Auth API", () => {
     assert.strictEqual(res.status, 201);
   });
 
-  // This test documents the bug — login returns 200 on wrong password
-  it("should return 200 on wrong password (known bug)", async () => {
+  it("should return 401 on wrong password", async () => {
     const res = await fetch(`http://localhost:${port}/auth/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username: "testuser", password: "wrongpass" }),
     });
-    // BUG: This should be 401, but the API returns 200
-    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.status, 401);
+  });
+
+  it("should return 401 for non-existent user", async () => {
+    const res = await fetch(`http://localhost:${port}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "nouser", password: "pass" }),
+    });
+    assert.strictEqual(res.status, 401);
   });
 });


### PR DESCRIPTION
Closes #1

## Summary
- Changed login endpoint to return 401 instead of 200 for invalid password and non-existent user
- Used generic "Invalid username or password" message for both cases to avoid user enumeration
- Updated existing test to assert 401 on wrong password and added new test for non-existent user

## Testing
- All 6 tests pass (`npm test`)
- No linter configured