### PR TITLE
Fix #2: Add ownership checks to task endpoints

### DIFF
--- a/src/tasks.js
+++ b/src/tasks.js
@@ -35,8 +35,11 @@ router.post("/", (req, res) => {
 router.get("/:id", (req, res) => {
   const task = tasks.find((t) => t.id === req.params.id);
 
-  if (!task || task.userId !== req.user.id) {
+  if (!task) {
     return res.status(404).json({ error: "Task not found" });
+  }
+  if (task.userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
   }
 
   res.json(task);
@@ -46,8 +49,11 @@ router.get("/:id", (req, res) => {
 router.put("/:id", (req, res) => {
   const index = tasks.findIndex((t) => t.id === req.params.id);
 
-  if (index === -1 || tasks[index].userId !== req.user.id) {
+  if (index === -1) {
     return res.status(404).json({ error: "Task not found" });
+  }
+  if (tasks[index].userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
   }
 
   const { title, description, completed } = req.body;
@@ -67,8 +73,11 @@ router.put("/:id", (req, res) => {
 router.delete("/:id", (req, res) => {
   const index = tasks.findIndex((t) => t.id === req.params.id);
 
-  if (index === -1 || tasks[index].userId !== req.user.id) {
+  if (index === -1) {
     return res.status(404).json({ error: "Task not found" });
+  }
+  if (tasks[index].userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
   }
 
   tasks.splice(index, 1);

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -35,12 +35,8 @@ router.post("/", (req, res) => {
 router.get("/:id", (req, res) => {
   const task = tasks.find((t) => t.id === req.params.id);
 
-  if (!task) {
+  if (!task || task.userId !== req.user.id) {
     return res.status(404).json({ error: "Task not found" });
-  }
-
-  if (task.userId !== req.user.id) {
-    return res.status(403).json({ error: "Forbidden" });
   }
 
   res.json(task);
@@ -50,12 +46,8 @@ router.get("/:id", (req, res) => {
 router.put("/:id", (req, res) => {
   const index = tasks.findIndex((t) => t.id === req.params.id);
 
-  if (index === -1) {
+  if (index === -1 || tasks[index].userId !== req.user.id) {
     return res.status(404).json({ error: "Task not found" });
-  }
-
-  if (tasks[index].userId !== req.user.id) {
-    return res.status(403).json({ error: "Forbidden" });
   }
 
   const { title, description, completed } = req.body;
@@ -75,12 +67,8 @@ router.put("/:id", (req, res) => {
 router.delete("/:id", (req, res) => {
   const index = tasks.findIndex((t) => t.id === req.params.id);
 
-  if (index === -1) {
+  if (index === -1 || tasks[index].userId !== req.user.id) {
     return res.status(404).json({ error: "Task not found" });
-  }
-
-  if (tasks[index].userId !== req.user.id) {
-    return res.status(403).json({ error: "Forbidden" });
   }
 
   tasks.splice(index, 1);

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -8,10 +8,9 @@ const router = express.Router();
 // All task routes require auth
 router.use(authenticate);
 
-// List tasks — returns ALL tasks, not just the user's
-// BUG: No ownership filtering — any user can see all tasks
+// List tasks — filtered to current user's tasks only
 router.get("/", (req, res) => {
-  res.json(tasks);
+  res.json(tasks.filter((t) => t.userId === req.user.id));
 });
 
 // Create task

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -40,7 +40,10 @@ router.get("/:id", (req, res) => {
     return res.status(404).json({ error: "Task not found" });
   }
 
-  // BUG: No ownership check — any user can view any task
+  if (task.userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
   res.json(task);
 });
 
@@ -52,7 +55,10 @@ router.put("/:id", (req, res) => {
     return res.status(404).json({ error: "Task not found" });
   }
 
-  // BUG: No ownership check — any user can update any task
+  if (tasks[index].userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
   const { title, description, completed } = req.body;
   tasks[index] = {
     ...tasks[index],
@@ -66,8 +72,7 @@ router.put("/:id", (req, res) => {
 });
 
 // Delete task
-// BUG: Doesn't check ownership — any user can delete any task
-// BUG: Returns 200 with empty body instead of 204
+// Delete task
 router.delete("/:id", (req, res) => {
   const index = tasks.findIndex((t) => t.id === req.params.id);
 
@@ -75,8 +80,12 @@ router.delete("/:id", (req, res) => {
     return res.status(404).json({ error: "Task not found" });
   }
 
+  if (tasks[index].userId !== req.user.id) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
   tasks.splice(index, 1);
-  res.status(200).json({});
+  res.status(204).send();
 });
 
 module.exports = router;

--- a/src/tasks.test.js
+++ b/src/tasks.test.js
@@ -101,14 +101,14 @@ describe("Task ownership", () => {
     taskId = task.id;
   });
 
-  it("should return 403 when getting another user's task", async () => {
+  it("should return 404 when getting another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       headers: { Authorization: `Bearer ${otherToken}` },
     });
-    assert.strictEqual(res.status, 403);
+    assert.strictEqual(res.status, 404);
   });
 
-  it("should return 403 when updating another user's task", async () => {
+  it("should return 404 when updating another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       method: "PUT",
       headers: {
@@ -117,15 +117,15 @@ describe("Task ownership", () => {
       },
       body: JSON.stringify({ title: "Hacked" }),
     });
-    assert.strictEqual(res.status, 403);
+    assert.strictEqual(res.status, 404);
   });
 
-  it("should return 403 when deleting another user's task", async () => {
+  it("should return 404 when deleting another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${otherToken}` },
     });
-    assert.strictEqual(res.status, 403);
+    assert.strictEqual(res.status, 404);
   });
 
   it("should allow owner to delete their own task", async () => {

--- a/src/tasks.test.js
+++ b/src/tasks.test.js
@@ -69,6 +69,74 @@ describe("Tasks API", () => {
   });
 });
 
+describe("Task ownership", () => {
+  let otherToken;
+  let taskId;
+
+  before(async () => {
+    // Register a second user
+    await fetch(`http://localhost:${port}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "otheruser", password: "otherpass", email: "other@test.com" }),
+    });
+    const loginRes = await fetch(`http://localhost:${port}/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "otheruser", password: "otherpass" }),
+    });
+    const loginData = await loginRes.json();
+    otherToken = loginData.token;
+
+    // Create a task as the original user
+    const taskRes = await fetch(`http://localhost:${port}/tasks`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${userToken}`,
+      },
+      body: JSON.stringify({ title: "Owned task", description: "Belongs to testuser" }),
+    });
+    const task = await taskRes.json();
+    taskId = task.id;
+  });
+
+  it("should return 403 when getting another user's task", async () => {
+    const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
+      headers: { Authorization: `Bearer ${otherToken}` },
+    });
+    assert.strictEqual(res.status, 403);
+  });
+
+  it("should return 403 when updating another user's task", async () => {
+    const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${otherToken}`,
+      },
+      body: JSON.stringify({ title: "Hacked" }),
+    });
+    assert.strictEqual(res.status, 403);
+  });
+
+  it("should return 403 when deleting another user's task", async () => {
+    const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${otherToken}` },
+    });
+    assert.strictEqual(res.status, 403);
+  });
+
+  it("should allow owner to delete their own task", async () => {
+    const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${userToken}` },
+    });
+    assert.strictEqual(res.status, 204);
+  });
+});
+
 describe("Auth API", () => {
   it("should register a new user", async () => {
     const res = await fetch(`http://localhost:${port}/auth/register`, {

--- a/src/tasks.test.js
+++ b/src/tasks.test.js
@@ -101,14 +101,14 @@ describe("Task ownership", () => {
     taskId = task.id;
   });
 
-  it("should return 404 when getting another user's task", async () => {
+  it("should return 403 when getting another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       headers: { Authorization: `Bearer ${otherToken}` },
     });
-    assert.strictEqual(res.status, 404);
+    assert.strictEqual(res.status, 403);
   });
 
-  it("should return 404 when updating another user's task", async () => {
+  it("should return 403 when updating another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       method: "PUT",
       headers: {
@@ -117,15 +117,15 @@ describe("Task ownership", () => {
       },
       body: JSON.stringify({ title: "Hacked" }),
     });
-    assert.strictEqual(res.status, 404);
+    assert.strictEqual(res.status, 403);
   });
 
-  it("should return 404 when deleting another user's task", async () => {
+  it("should return 403 when deleting another user's task", async () => {
     const res = await fetch(`http://localhost:${port}/tasks/${taskId}`, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${otherToken}` },
     });
-    assert.strictEqual(res.status, 404);
+    assert.strictEqual(res.status, 403);
   });
 
   it("should allow owner to delete their own task", async () => {


### PR DESCRIPTION
Closes #2

## Summary
- Added `403 Forbidden` ownership guard to `GET /:id`, `PUT /:id`, and `DELETE /:id` in `src/tasks.js` — each endpoint now verifies `task.userId === req.user.id` before proceeding
- Fixed `DELETE /:id` to return `204 No Content` instead of `200` with empty body
- Added multi-user ownership tests covering all three forbidden cases plus a positive owner-delete case

## Testing
- All 9 tests pass (`npm test`), including 4 new ownership tests
- No linter configured; no build step required

🤖 Generated with [Claude Code](https://claude.com/claude-code)